### PR TITLE
Enables parsing dotfiles

### DIFF
--- a/src/Command/CreatePhpLibrary.php
+++ b/src/Command/CreatePhpLibrary.php
@@ -86,7 +86,7 @@ final class CreatePhpLibrary extends AbstractCommand
         $this->updateLicenseFile('LICENSE.md', $values['license']);
 
         $finder = new Finder();
-        $finder->files()->in(getcwd());
+        $finder->files()->ignoreDotFiles(false)->in(getcwd());
 
         foreach ($finder as $file) {
             $this->replaceVariablesInFile($values, $file->getRealPath());

--- a/src/Command/CreateZFApplication.php
+++ b/src/Command/CreateZFApplication.php
@@ -83,7 +83,7 @@ final class CreateZFApplication extends AbstractCommand
         $this->updateLicenseFile('LICENSE.md', $values['license']);
 
         $finder = new Finder();
-        $finder->files()->in(getcwd());
+        $finder->files()->ignoreDotFiles(false)->in(getcwd());
 
         foreach ($finder as $file) {
             $this->replaceVariablesInFile($values, $file->getRealPath());


### PR DESCRIPTION
When processing a .travis file for example dot files shouldn't be ignored
which they are, by default.